### PR TITLE
Add null type parser

### DIFF
--- a/jambo/parser/__init__.py
+++ b/jambo/parser/__init__.py
@@ -7,6 +7,7 @@ from .const_type_parser import ConstTypeParser
 from .enum_type_parser import EnumTypeParser
 from .float_type_parser import FloatTypeParser
 from .int_type_parser import IntTypeParser
+from .null_type_parser import NullTypeParser
 from .object_type_parser import ObjectTypeParser
 from .ref_type_parser import RefTypeParser
 from .string_type_parser import StringTypeParser
@@ -22,6 +23,7 @@ __all__ = [
     "BooleanTypeParser",
     "FloatTypeParser",
     "IntTypeParser",
+    "NullTypeParser",
     "ObjectTypeParser",
     "StringTypeParser",
     "RefTypeParser",

--- a/jambo/parser/null_type_parser.py
+++ b/jambo/parser/null_type_parser.py
@@ -1,0 +1,25 @@
+from jambo.parser._type_parser import GenericTypeParser
+from jambo.types.type_parser_options import TypeParserOptions
+
+from typing_extensions import Unpack
+
+
+class NullTypeParser(GenericTypeParser):
+    mapped_type = None
+
+    json_schema_type = "type:null"
+
+    type_mappings = {
+        "default": "default",
+    }
+
+    def from_properties_impl(
+        self, name, properties, **kwargs: Unpack[TypeParserOptions]
+    ):
+        mapped_properties = self.mappings_properties_builder(properties, **kwargs)
+
+        default_value = properties.get("default")
+        if default_value is not None:
+            raise ValueError(f"Default value for {name} must be None.")
+
+        return None, mapped_properties

--- a/tests/parser/test_null_type_parser.py
+++ b/tests/parser/test_null_type_parser.py
@@ -1,0 +1,43 @@
+from jambo.parser import NullTypeParser
+
+from unittest import TestCase
+
+
+class TestNullTypeParser(TestCase):
+    def test_null_parser_no_options(self):
+        parser = NullTypeParser()
+
+        properties = {"type": "null"}
+
+        type_parsing, type_validator = parser.from_properties_impl(
+            "placeholder", properties
+        )
+
+        self.assertEqual(type_parsing, None)
+        self.assertEqual(type_validator, {"default": None})
+
+    def test_null_parser_with_default(self):
+        parser = NullTypeParser()
+
+        properties = {
+            "type": "null",
+            "default": None,
+        }
+
+        type_parsing, type_validator = parser.from_properties_impl(
+            "placeholder", properties
+        )
+
+        self.assertEqual(type_parsing, None)
+        self.assertEqual(type_validator["default"], None)
+
+    def test_null_parser_with_invalid_default(self):
+        parser = NullTypeParser()
+
+        properties = {
+            "type": "null",
+            "default": "invalid",
+        }
+
+        with self.assertRaises(ValueError):
+            parser.from_properties_impl("placeholder", properties)


### PR DESCRIPTION
I was trying to create a model with a schema containing fields like

```
'a_thing': {'anyOf': [{'type': 'number'},
                      {'type': 'null'}],
            'default': None}
```

but failing with the error

```
ValueError: Unknown type
```

To address this I've added a parser for the [null](https://json-schema.org/understanding-json-schema/reference/null) type based on the boolean and integer parsers.

With this change, the example

```python
from jambo import SchemaConverter


schema = {
    "title": "Person",
    "type": "object",
    "properties": {
        "name": {"type": "string"},
        "age": {"type": "integer"},
        "void": {"type": "null"},
    },
    "required": ["name"],
}

Person = SchemaConverter.build(schema)

obj = Person(name="Alice", age=30)
print(obj)
```

as expected produces

```console
$ python jambo_test.py 
name='Alice' age=30 void=None
```
PS - this library looks like it'll be really useful, thanks!
