### PR TITLE
add string duration -> timedelta

### DIFF
--- a/jambo/parser/string_type_parser.py
+++ b/jambo/parser/string_type_parser.py
@@ -4,7 +4,7 @@ from jambo.types.type_parser_options import TypeParserOptions
 from pydantic import EmailStr, HttpUrl, IPvAnyAddress
 from typing_extensions import Unpack
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 
 
 class StringTypeParser(GenericTypeParser):
@@ -28,6 +28,7 @@ class StringTypeParser(GenericTypeParser):
         "date": date,
         "time": time,
         "date-time": datetime,
+        "duration": timedelta,
     }
 
     format_pattern_mapping = {

--- a/tests/parser/test_string_type_parser.py
+++ b/tests/parser/test_string_type_parser.py
@@ -2,7 +2,7 @@ from jambo.parser import StringTypeParser
 
 from pydantic import EmailStr, HttpUrl, IPvAnyAddress
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from unittest import TestCase
 
 
@@ -197,3 +197,15 @@ class TestStringTypeParser(TestCase):
         type_parsing, type_validator = parser.from_properties("placeholder", properties)
 
         self.assertEqual(type_parsing, datetime)
+
+    def test_string_parser_with_timedelta_format(self):
+        parser = StringTypeParser()
+
+        properties = {
+            "type": "string",
+            "format": "duration",
+        }
+
+        type_parsing, type_validator = parser.from_properties("placeholder", properties)
+
+        self.assertEqual(type_parsing, timedelta)


### PR DESCRIPTION
```python
BaseModel.model_json_schema()
```
with a `timedelta` field generates JSON with
```
    format: 'duration',
    type: 'string'
```
which when fed back into
```python
SchemaConverter.build()
```
raises 
```
ValueError: Unsupported string format: duration
```

This PR adds `duration` -> `timedelta`.