### PR TITLE
Fix/required array field not honored

### DIFF
--- a/jambo/parser/array_type_parser.py
+++ b/jambo/parser/array_type_parser.py
@@ -35,7 +35,7 @@ class ArrayTypeParser(GenericTypeParser):
 
         mapped_properties = self.mappings_properties_builder(properties, **kwargs)
 
-        if "default" not in mapped_properties:
+        if "default" in properties or not kwargs.get("required", False):
             mapped_properties["default_factory"] = self._build_default_factory(
                 properties.get("default"), wrapper_type
             )

--- a/jambo/parser/object_type_parser.py
+++ b/jambo/parser/object_type_parser.py
@@ -59,7 +59,7 @@ class ObjectTypeParser(GenericTypeParser):
 
         fields = {}
         for name, prop in properties.items():
-            sub_property = kwargs.copy()
+            sub_property: TypeParserOptions = kwargs.copy()
             sub_property["required"] = name in required_keys
 
             parsed_type, parsed_properties = GenericTypeParser.type_from_properties(

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -205,6 +205,9 @@ class TestSchemaConverter(TestCase):
         )
 
         with self.assertRaises(ValueError):
+            model()
+
+        with self.assertRaises(ValueError):
             model(friends=[])
 
         with self.assertRaises(ValueError):

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -181,7 +181,7 @@ class TestSchemaConverter(TestCase):
 
         self.assertEqual(model(is_active="true").is_active, True)
 
-    def test_validation_list(self):
+    def test_validation_list_with_valid_items(self):
         schema = {
             "title": "Person",
             "description": "A person",
@@ -205,13 +205,50 @@ class TestSchemaConverter(TestCase):
         )
 
         with self.assertRaises(ValueError):
-            model()
-
-        with self.assertRaises(ValueError):
             model(friends=[])
 
         with self.assertRaises(ValueError):
             model(friends=["John", "Jane", "Invalid"])
+
+    def test_validation_list_with_missing_items(self):
+        model = SchemaConverter.build(
+            {
+                "title": "Person",
+                "description": "A person",
+                "type": "object",
+                "properties": {
+                    "friends": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "maxItems": 2,
+                        "default": ["John", "Jane"],
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(model().friends, ["John", "Jane"])
+
+        model = SchemaConverter.build(
+            {
+                "title": "Person",
+                "description": "A person",
+                "type": "object",
+                "properties": {
+                    "friends": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "maxItems": 2,
+                    },
+                },
+                "required": ["friends"],
+            }
+        )
+
+        with self.assertRaises(ValueError):
+            model()
 
     def test_validation_object(self):
         schema = {
@@ -237,6 +274,9 @@ class TestSchemaConverter(TestCase):
 
         self.assertEqual(obj.address.street, "123 Main St")
         self.assertEqual(obj.address.city, "Springfield")
+
+        with self.assertRaises(ValueError):
+            model()
 
     def test_default_for_string(self):
         schema = {


### PR DESCRIPTION
Fixes the issue [#34].

Caused by a check in the wrong property mapping causing all fields of type array to have a default factory even when the field doesn't provide a default and is required