### PR TITLE
(fix): Adds check for discriminator type

### DIFF
--- a/tests/parser/test_oneof_type_parser.py
+++ b/tests/parser/test_oneof_type_parser.py
@@ -196,6 +196,29 @@ class TestOneOfTypeParser(TestCase):
         with self.assertRaises(ValueError):
             Model(pet={"type": "bird", "flies": True})
 
+    def test_oneof_with_invalid_types(self):
+        with self.assertRaises(ValueError):
+            SchemaConverter.build(
+                {
+                    "title": "Pet",
+                    "type": "object",
+                    "properties": {
+                        "pet": {
+                            "oneOf": [
+                                {
+                                    "type": "number",
+                                },
+                                {
+                                    "type": "string",
+                                },
+                            ],
+                            "discriminator": {"propertyName": "type"},
+                        }
+                    },
+                    "required": ["pet"],
+                }
+            )
+
     def test_oneof_with_discriminator_mapping(self):
         schema = {
             "title": "Vehicle",


### PR DESCRIPTION
This pull request enhances the handling of `oneOf` schemas with discriminators in the `jambo` parser by enforcing that all subfield types must be objects (i.e., subclasses of `BaseModel`) when a discriminator is used. It also adds a corresponding test to ensure this validation works as expected.

### Validation improvements for discriminators

* Updated `_build_type_one_of_with_discriminator` in `oneof_type_parser.py` to check that all subfield types are objects (subclasses of `BaseModel`) when a discriminator is present, raising a `ValueError` if not.

### Testing

* Added `test_oneof_with_invalid_types` to verify that using non-object types in a `oneOf` with a discriminator raises a `ValueError`.