### PR TITLE
(improvement): Adds More Type Formats to String Parser

### DIFF
--- a/jambo/parser/string_type_parser.py
+++ b/jambo/parser/string_type_parser.py
@@ -1,10 +1,12 @@
 from jambo.parser._type_parser import GenericTypeParser
 from jambo.types.type_parser_options import TypeParserOptions
 
-from pydantic import EmailStr, HttpUrl, IPvAnyAddress
+from pydantic import AnyUrl, EmailStr
 from typing_extensions import Unpack
 
 from datetime import date, datetime, time, timedelta
+from ipaddress import IPv4Address, IPv6Address
+from uuid import UUID
 
 
 class StringTypeParser(GenericTypeParser):
@@ -20,15 +22,22 @@ class StringTypeParser(GenericTypeParser):
     }
 
     format_type_mapping = {
-        "email": EmailStr,
-        "uri": HttpUrl,
-        "ipv4": IPvAnyAddress,
-        "ipv6": IPvAnyAddress,
-        "hostname": str,
+        # 7.3.1. Dates, Times, and Duration
         "date": date,
         "time": time,
         "date-time": datetime,
         "duration": timedelta,
+        # 7.3.2. Email Addresses
+        "email": EmailStr,
+        # 7.3.3. Hostnames
+        "hostname": str,
+        # 7.3.4. IP Addresses
+        "ipv4": IPv4Address,
+        "ipv6": IPv6Address,
+        # 7.3.5. Resource Identifiers
+        "uri": AnyUrl,
+        # "iri" # Not supported by pydantic and currently not supported by jambo
+        "uuid": UUID,
     }
 
     format_pattern_mapping = {

--- a/tests/parser/test_string_type_parser.py
+++ b/tests/parser/test_string_type_parser.py
@@ -5,6 +5,7 @@ from pydantic import AnyUrl, EmailStr
 from datetime import date, datetime, time, timedelta
 from ipaddress import IPv4Address, IPv6Address
 from unittest import TestCase
+from uuid import UUID
 
 
 class TestStringTypeParser(TestCase):
@@ -130,6 +131,18 @@ class TestStringTypeParser(TestCase):
             )
 
             self.assertEqual(type_parsing, expected_type)
+
+    def test_string_parser_with_uuid_format(self):
+        parser = StringTypeParser()
+
+        properties = {
+            "type": "string",
+            "format": "uuid",
+        }
+
+        type_parsing, type_validator = parser.from_properties("placeholder", properties)
+
+        self.assertEqual(type_parsing, UUID)
 
     def test_string_parser_with_time_format(self):
         parser = StringTypeParser()

--- a/tests/parser/test_string_type_parser.py
+++ b/tests/parser/test_string_type_parser.py
@@ -1,8 +1,9 @@
 from jambo.parser import StringTypeParser
 
-from pydantic import EmailStr, HttpUrl, IPvAnyAddress
+from pydantic import AnyUrl, EmailStr
 
 from datetime import date, datetime, time, timedelta
+from ipaddress import IPv4Address, IPv6Address
 from unittest import TestCase
 
 
@@ -111,12 +112,14 @@ class TestStringTypeParser(TestCase):
 
         type_parsing, type_validator = parser.from_properties("placeholder", properties)
 
-        self.assertEqual(type_parsing, HttpUrl)
+        self.assertEqual(type_parsing, AnyUrl)
 
     def test_string_parser_with_ip_formats(self):
         parser = StringTypeParser()
 
-        for ip_format in ["ipv4", "ipv6"]:
+        formats = {"ipv4": IPv4Address, "ipv6": IPv6Address}
+
+        for ip_format, expected_type in formats.items():
             properties = {
                 "type": "string",
                 "format": ip_format,
@@ -126,7 +129,7 @@ class TestStringTypeParser(TestCase):
                 "placeholder", properties
             )
 
-            self.assertEqual(type_parsing, IPvAnyAddress)
+            self.assertEqual(type_parsing, expected_type)
 
     def test_string_parser_with_time_format(self):
         parser = StringTypeParser()

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -4,6 +4,7 @@ from pydantic import AnyUrl, BaseModel
 
 from ipaddress import IPv4Address, IPv6Address
 from unittest import TestCase
+from uuid import UUID
 
 
 def is_pydantic_model(cls):
@@ -492,6 +493,22 @@ class TestSchemaConverter(TestCase):
         )
         with self.assertRaises(ValueError):
             model(ip="invalid-ipv6")
+
+    def test_string_format_uuid(self):
+        schema = {
+            "title": "UUIDTest",
+            "type": "object",
+            "properties": {"id": {"type": "string", "format": "uuid"}},
+        }
+        model = SchemaConverter.build(schema)
+
+        self.assertEqual(
+            model(id="123e4567-e89b-12d3-a456-426614174000").id,
+            UUID("123e4567-e89b-12d3-a456-426614174000"),
+        )
+
+        with self.assertRaises(ValueError):
+            model(id="invalid-uuid")
 
     def test_string_format_hostname(self):
         schema = {

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -1,6 +1,6 @@
 from jambo import SchemaConverter
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import AnyUrl, BaseModel
 
 from ipaddress import IPv4Address, IPv6Address
 from unittest import TestCase
@@ -463,7 +463,7 @@ class TestSchemaConverter(TestCase):
         }
         model = SchemaConverter.build(schema)
         self.assertEqual(
-            model(website="https://example.com").website, HttpUrl("https://example.com")
+            model(website="https://example.com").website, AnyUrl("https://example.com")
         )
         with self.assertRaises(ValueError):
             model(website="invalid-uri")


### PR DESCRIPTION
This pull request updates how string formats are parsed and validated, aligning the implementation with the latest pydantic types and improving standards compliance. The changes include switching from generic types to more specific ones for URLs and IP addresses, updating the corresponding parser logic, and adjusting the tests to match these changes.

**Parser improvements and standards compliance:**

* Updated `StringTypeParser` to use `AnyUrl` instead of `HttpUrl` for the `"uri"` format, and to use `IPv4Address`/`IPv6Address` instead of `IPvAnyAddress` for `"ipv4"` and `"ipv6"` formats. The `"uuid"` format is also now supported using the `UUID` type. (`jambo/parser/string_type_parser.py`) [[1]](diffhunk://#diff-c015f8e8aa329bed6e1ef3b8f808ef126f8fc98cbcda76ce1fef73dffa32f7e4L4-R9) [[2]](diffhunk://#diff-c015f8e8aa329bed6e1ef3b8f808ef126f8fc98cbcda76ce1fef73dffa32f7e4L23-R40)

**Test updates:**

* Updated tests to expect `AnyUrl` instead of `HttpUrl` for URI formats and to expect `IPv4Address`/`IPv6Address` instead of `IPvAnyAddress` for IP formats. (`tests/parser/test_string_type_parser.py`, `tests/test_schema_converter.py`) [[1]](diffhunk://#diff-a04dd229fa580e9b8381b07750c65b2aff073ce3d5d5e0932e37216efc6af738L3-R6) [[2]](diffhunk://#diff-a04dd229fa580e9b8381b07750c65b2aff073ce3d5d5e0932e37216efc6af738L114-R122) [[3]](diffhunk://#diff-a04dd229fa580e9b8381b07750c65b2aff073ce3d5d5e0932e37216efc6af738L129-R132) [[4]](diffhunk://#diff-04f19b964ef1fadc9b51ecb3b8ddff05392ba340be55cccf56c5a8ca49c11d5aL3-R3) [[5]](diffhunk://#diff-04f19b964ef1fadc9b51ecb3b8ddff05392ba340be55cccf56c5a8ca49c11d5aL466-R466)