### PR TITLE
Fix Field deprecation warning resulting from building models with formatted strings

### DIFF
--- a/jambo/parser/string_type_parser.py
+++ b/jambo/parser/string_type_parser.py
@@ -19,7 +19,6 @@ class StringTypeParser(GenericTypeParser):
         "maxLength": "max_length",
         "minLength": "min_length",
         "pattern": "pattern",
-        "format": "format",
     }
 
     format_type_mapping = {
@@ -62,5 +61,9 @@ class StringTypeParser(GenericTypeParser):
         mapped_type = self.format_type_mapping[format_type]
         if format_type in self.format_pattern_mapping:
             mapped_properties["pattern"] = self.format_pattern_mapping[format_type]
+
+        if "json_schema_extra" not in mapped_properties:
+            mapped_properties["json_schema_extra"] = {}
+        mapped_properties["json_schema_extra"]["format"] = format_type
 
         return mapped_type, mapped_properties


### PR DESCRIPTION
When building a data model using `SchemaConverter.build()` from a JSON schema with a string field having a format this warning is generated:

```
PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'format'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```

This is a result of the "format" keyword being passed to Pydantic's `Field()`. This is a deprecated [string constraint](https://docs.pydantic.dev/latest/concepts/fields/#string-constraints) and no longer shown as possible in Pydantic's documentation.

To resolve this issue, the format property can instead be passed using the `json_schema_extra` keyword - part of Pydantic's support for [customising the JSON schema](https://docs.pydantic.dev/latest/concepts/json_schema/#field-level-customization).

The warning can be generated by either running the tests or using the following example code:

```python
import warnings
from datetime import datetime
from jambo import SchemaConverter
from pydantic import BaseModel
from typing import Optional

warnings.simplefilter('always')


class TestModel(BaseModel):
    a_datetime: Optional[datetime] | None = None


schema = TestModel.model_json_schema()
print("Got schema")

rebuilt_model = SchemaConverter.build(schema)
print("Built model")
```

After this is PR is applied no other behaviour should change other than the warning is no longer generated.

This PR is a partial revert of fbbff0b.