### PR TITLE
feat: adds title and deprecated to the list of default mappings in th…

### DIFF
--- a/jambo/parser/_type_parser.py
+++ b/jambo/parser/_type_parser.py
@@ -19,6 +19,8 @@ class GenericTypeParser(ABC, Generic[T]):
         "default": "default",
         "description": "description",
         "examples": "examples",
+        "title": "title",
+        "deprecated": "deprecated",
     }
 
     @abstractmethod


### PR DESCRIPTION
Solves issue #55 

---

This pull request introduces two new metadata fields to the type parser in `jambo/parser/_type_parser.py`. The changes expand the supported attributes for parsed types.

Supported mapping improvements:

* Added `"title"` and `"deprecated"`