### PR TITLE
fix: fixes invalid subobject required

### DIFF
--- a/jambo/parser/object_type_parser.py
+++ b/jambo/parser/object_type_parser.py
@@ -23,9 +23,13 @@ class ObjectTypeParser(GenericTypeParser):
         )
         type_properties = self.mappings_properties_builder(properties, **kwargs)
 
-        if (default_value := type_properties.pop("default", None)) is not None:
-            type_properties["default_factory"] = lambda: type_parsing.model_validate(
-                default_value
+        if (
+            default_value := type_properties.pop("default", None)
+        ) is not None or not kwargs.get("required", False):
+            type_properties["default_factory"] = (
+                lambda: type_parsing.model_validate(default_value)
+                if default_value is not None
+                else None
             )
 
         if (example_values := type_properties.pop("examples", None)) is not None:

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -836,3 +836,33 @@ class TestSchemaConverter(TestCase):
         second_type = get_args(arg2)[0]
 
         self.assertNotEqual(first_type.__name__, second_type.__name__)
+
+    def test_object_invalid_require(self):
+        # https://github.com/HideyoshiNakazone/jambo/issues/60
+        object_ = SchemaConverter.build(
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "title": "TEST",
+                "type": "object",
+                "required": ["title"],
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "The title of the object",
+                    },
+                    "description": {
+                        "type": "object",
+                        "properties": {
+                            "summary": {
+                                "type": "string",
+                            },
+                            "details": {
+                                "type": "string",
+                            },
+                        },
+                    },
+                },
+            }
+        )
+
+        self.assertFalse(object_.model_fields["description"].is_required())  # FAIL


### PR DESCRIPTION
Solves [#60](https://github.com/HideyoshiNakazone/jambo/issues/60)

---

This pull request introduces an improvement to the handling of default values for object properties in the parser, as well as a new test to validate the behavior when required fields are specified incorrectly in object schemas. These changes help ensure that optional object properties are correctly initialized and that schema conversion adheres to expected requirements logic.

**Object property defaults and schema validation:**

* Updated the logic in `jambo/parser/object_type_parser.py` to ensure that if a property is not marked as required, its `default_factory` is set to return `None` unless a default value is provided. This change improves the handling of optional fields by making sure they default to `None` when not required or not explicitly given a default value.

**Testing schema conversion edge cases:**

* Added a new test `test_object_invalid_require` in `tests/test_schema_converter.py` to verify that object properties not listed as required are correctly treated as optional, even when nested within other properties. This test checks that the `description` field is not required, helping to catch potential issues with required field logic in schema conversion.