### PR TITLE
chore: improves documentation and readme

### DIFF
--- a/docs/source/usage.ref_cache.rst
+++ b/docs/source/usage.ref_cache.rst
@@ -10,6 +10,12 @@ and :py:meth:`SchemaConverter.build <jambo.SchemaConverter.build>`.
 However, only :py:meth:`SchemaConverter.build_with_cache <jambo.SchemaConverter.build_with_cache>` exposes the cache through a supported API;
 :py:meth:`SchemaConverter.build <jambo.SchemaConverter.build>` uses the cache internally and does not provide access to it.
 
+The reference cache accepts a mutable mapping (typically a plain Python dict)
+that maps reference names (strings) to generated Pydantic model classes.
+Since only the reference names are stored it can cause name collisions if
+multiple schemas with overlapping names are processed using the same cache.
+Therefore, it's recommended that each namespace or schema source uses its own
+:class:`SchemaConverter` instance.
 
 -----------------------------------------
 Configuring and Using the Reference Cache

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -42,7 +42,7 @@ Static Method (no config)
 
 The :py:meth:`SchemaConverter.build <jambo.SchemaConverter.build>` static method takes a JSON Schema dictionary and returns a Pydantic model class.
 
-Note: the static ``build`` method was the original public API of this library and is kept for backwards compatibility. It creates and returns a model class for the provided schema but does not expose or persist an instance cache.
+Note: the static ``build`` method was the original public API of this library. It creates and returns a model class for the provided schema but does not expose or persist an instance cache.
 
 
 --------------------------------
@@ -96,6 +96,11 @@ Unlike the original static :py:meth:`SchemaConverter.build <jambo.SchemaConverte
 the instance method persists and exposes the reference cache and provides helpers such as
 :py:meth:`SchemaConverter.get_cached_ref <jambo.SchemaConverter.get_cached_ref>` and
 :py:meth:`SchemaConverter.clear_ref_cache <jambo.SchemaConverter.clear_ref_cache>`.
+
+.. warning::
+    The instance API with reference cache can lead to schema and type name collisions if not managed carefully.
+    It's recommended that each namespace or schema source uses its own `SchemaConverter` instance.
+    If you don't need cache control, the static API is simpler and sufficient for most use cases.
 
 For details and examples about the reference cache and the different cache modes (instance cache, per-call cache, ephemeral cache), see:
 


### PR DESCRIPTION
This pull request updates documentation to clarify the two APIs for building models with `SchemaConverter`, highlights the new instance API and its reference cache, and adds usage examples and warnings about potential schema/type name collisions. The changes help users understand when to use each API and how to avoid cache-related issues.

### Documentation improvements for usage and cache control

* Added a clear explanation in `README.md` of the two APIs (`build` and `build_with_cache`) for generating Pydantic models, including guidance on reference cache management and when to use each API.
* Introduced detailed usage examples for both the static and instance APIs in `README.md`, demonstrating how to build models, access cached references, and clear the cache.
* Added a warning in `docs/source/usage.rst` and expanded guidance in `docs/source/usage.ref_cache.rst` about possible schema and type name collisions when using the instance API and reference cache, recommending separate `SchemaConverter` instances per namespace or schema source. [[1]](diffhunk://#diff-66e28562c85a1bb96f431f2dd52bbabab914359e4b06f58eb1e18eadc01f5c06R100-R104) [[2]](diffhunk://#diff-49841fb126d70aa2f7d8735416eae7f32b0a5f6ea92830b7c8c355b513c22610R13-R18)

### Minor documentation and formatting updates

* Updated badge formatting and improved alt text for images in `README.md`.
* Fixed minor wording and grammar in feature descriptions and API explanations in `README.md` and `docs/source/usage.rst`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R28) [[2]](diffhunk://#diff-66e28562c85a1bb96f431f2dd52bbabab914359e4b06f58eb1e18eadc01f5c06L45-R45)