### PR TITLE
feat: adds support for list of types

### DIFF
--- a/jambo/parser/_type_parser.py
+++ b/jambo/parser/_type_parser.py
@@ -73,13 +73,11 @@ class GenericTypeParser(ABC, Generic[T]):
         :param kwargs: Additional options for type parsing.
         :return: A tuple containing the type and its properties.
         """
-        
-        parser = cls._get_impl(
-            cls._normalize_properties(properties)
-        )
+
+        parser = cls._get_impl(cls._normalize_properties(properties))
 
         return parser().from_properties(name=name, properties=properties, **kwargs)
-    
+
     @staticmethod
     def _normalize_properties(properties: JSONSchema) -> JSONSchema:
         """
@@ -87,21 +85,21 @@ class GenericTypeParser(ABC, Generic[T]):
         :param properties: The properties to be normalized.
         """
         type_value = properties.pop("type", None)
-        
+
         if isinstance(type_value, str):
             properties["type"] = type_value
             return properties
-        
+
         if isinstance(type_value, list) and len(type_value) == 0:
             raise InvalidSchemaException(
-                "Invalid schema: 'type' list cannot be empty", invalid_field=str(properties)
+                "Invalid schema: 'type' list cannot be empty",
+                invalid_field=str(properties),
             )
-
 
         if isinstance(type_value, list) and len(type_value) == 1:
             properties["type"] = type_value[0]
             return properties
-        
+
         if isinstance(type_value, list):
             properties["anyOf"] = [{"type": t} for t in type_value]
             return properties

--- a/jambo/schema_converter.py
+++ b/jambo/schema_converter.py
@@ -1,4 +1,4 @@
-from jambo.exceptions import InternalAssertionException, InvalidSchemaException, UnsupportedSchemaException
+from jambo.exceptions import InvalidSchemaException, UnsupportedSchemaException
 from jambo.parser import ObjectTypeParser, RefTypeParser
 from jambo.types import JSONSchema, RefCacheDict
 
@@ -135,11 +135,12 @@ class SchemaConverter:
         """
         if "$ref" in schema:
             return "$ref"
-        
+
         type_value = schema.get("type")
         if isinstance(type_value, list):
             raise InvalidSchemaException(
-                "Invalid schema: 'type' cannot be a list at the top level", invalid_field=str(schema)
+                "Invalid schema: 'type' cannot be a list at the top level",
+                invalid_field=str(schema),
             )
 
         return type_value

--- a/jambo/types/json_schema_type.py
+++ b/jambo/types/json_schema_type.py
@@ -42,7 +42,7 @@ JSONSchema = TypedDict(
         "description": str,
         "default": JSONType,
         "examples": List[JSONType],
-        "type": JSONSchemaType|List[JSONSchemaType],
+        "type": JSONSchemaType | List[JSONSchemaType],
         "enum": List[JSONType],
         "const": JSONType,
         "properties": Dict[str, "JSONSchema"],

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -1003,11 +1003,7 @@ class TestSchemaConverter(TestCase):
         schema = {
             "title": "TestListType",
             "type": "object",
-            "properties": {
-                "values": {
-                    "type": ["string", "number"]
-                }
-            },
+            "properties": {"values": {"type": ["string", "number"]}},
         }
 
         Model = self.converter.build_with_cache(schema)
@@ -1022,11 +1018,7 @@ class TestSchemaConverter(TestCase):
         schema = {
             "title": "TestListType",
             "type": "object",
-            "properties": {
-                "values": {
-                    "type": ["string"]
-                }
-            },
+            "properties": {"values": {"type": ["string"]}},
         }
 
         Model = self.converter.build_with_cache(schema)
@@ -1038,21 +1030,14 @@ class TestSchemaConverter(TestCase):
         schema = {
             "title": "TestListType",
             "type": "object",
-            "properties": {
-                "values": {
-                    "type": []
-                }
-            },
+            "properties": {"values": {"type": []}},
         }
 
         with self.assertRaises(InvalidSchemaException):
             self.converter.build_with_cache(schema)
 
     def test_parse_list_type_root_level_throws(self):
-        schema = {
-            "title": "TestListType",
-            "type": ["string", "number"]
-        }
+        schema = {"title": "TestListType", "type": ["string", "number"]}
 
         with self.assertRaises(InvalidSchemaException):
             self.converter.build_with_cache(schema)


### PR DESCRIPTION
Solves #59

---

This pull request improves the handling and parsing of JSON Schema `type` definitions, especially when the `type` field is a list, and adds corresponding tests to ensure correctness. The main changes include normalizing the `type` property in schemas, updating type annotations, and enhancing test coverage for edge cases.

### JSON Schema type normalization and parsing improvements

* Added a `_normalize_properties` static method in `jambo/parser/_type_parser.py` to standardize the `type` field in schema properties, handling cases where `type` is a string, a list with one item, a list with multiple items (converted to `anyOf`), or an empty list (raises `InvalidSchemaException`).
* Updated the `type` annotation in `jambo/types/json_schema_type.py` to accept both a single type and a list of types, reflecting the normalization logic.

### Test coverage for type parsing edge cases

* Added tests in `tests/test_schema_converter.py` to verify correct parsing when the `type` field is a list with multiple values, a list with a single value, and to ensure an error is raised for an empty list.