### PR TITLE
fix: fixes annotation definition in anyof parser

### DIFF
--- a/jambo/parser/anyof_type_parser.py
+++ b/jambo/parser/anyof_type_parser.py
@@ -42,8 +42,12 @@ class AnyOfTypeParser(GenericTypeParser):
         # By defining the type as Union of Annotated type we can use the Field validator
         # to enforce the constraints of each union type when needed.
         # We use Annotated to attach the Field validators to the type.
-        field_types = [
-            Annotated[t, Field(**v)] if v is not None else t for t, v in sub_types
-        ]
+        field_types = []
+        for subType, subProp in sub_types:
+            default_value = subProp.pop("default", None)
+            if default_value is None:
+                default_value = ...
+
+            field_types.append(Annotated[subType, Field(default_value, **subProp)])
 
         return Union[(*field_types,)], mapped_properties


### PR DESCRIPTION
This pull request refactors how default values are handled when constructing union types with field validators in the `from_properties_impl` method of `jambo/parser/anyof_type_parser.py`. The main change is to explicitly extract and set default values for each sub-type, ensuring that defaults are correctly applied in the annotated fields.

Field validator and default value handling:

* Refactored the construction of `field_types` to explicitly extract and set the `default` value from each sub-type's properties, using `...` as a fallback when no default is provided. This ensures that default values are correctly passed to the `Field` constructor for each annotated type.