### PR TITLE
chore: run tests in python3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a minor update to the Python build matrix in the GitHub Actions workflow. The change adds support for Python 3.14 to the list of tested versions.

* Added Python 3.14 to the `jobs:` build matrix in `.github/workflows/build.yml`, ensuring CI coverage for the latest Python release.