### PR TITLE
feat: Add binary and file-path string format support

### DIFF
--- a/jambo/parser/string_type_parser.py
+++ b/jambo/parser/string_type_parser.py
@@ -2,7 +2,7 @@ from jambo.exceptions import InvalidSchemaException
 from jambo.parser._type_parser import GenericTypeParser
 from jambo.types.type_parser_options import TypeParserOptions
 
-from pydantic import AnyUrl, EmailStr, TypeAdapter, ValidationError
+from pydantic import AnyUrl, EmailStr, FilePath, TypeAdapter, ValidationError
 from typing_extensions import Unpack
 
 from datetime import date, datetime, time, timedelta
@@ -38,6 +38,9 @@ class StringTypeParser(GenericTypeParser):
         "uri": AnyUrl,
         # "iri" # Not supported by pydantic and currently not supported by jambo
         "uuid": UUID,
+        # Additional formats
+        "binary": bytes,
+        "file-path": FilePath,
     }
 
     format_pattern_mapping = {

--- a/tests/parser/test_string_type_parser.py
+++ b/tests/parser/test_string_type_parser.py
@@ -1,7 +1,7 @@
 from jambo.exceptions import InvalidSchemaException
 from jambo.parser import StringTypeParser
 
-from pydantic import AnyUrl, EmailStr
+from pydantic import AnyUrl, EmailStr, FilePath
 
 from datetime import date, datetime, time, timedelta, timezone
 from ipaddress import IPv4Address, IPv6Address, ip_address
@@ -319,3 +319,27 @@ class TestStringTypeParser(TestCase):
                 timedelta(seconds=0.5),
             ],
         )
+
+    def test_string_parser_with_binary_format(self):
+        parser = StringTypeParser()
+
+        properties = {
+            "type": "string",
+            "format": "binary",
+        }
+
+        type_parsing, type_validator = parser.from_properties("placeholder", properties)
+
+        self.assertEqual(type_parsing, bytes)
+
+    def test_string_parser_with_file_path_format(self):
+        parser = StringTypeParser()
+
+        properties = {
+            "type": "string",
+            "format": "file-path",
+        }
+
+        type_parsing, type_validator = parser.from_properties("placeholder", properties)
+
+        self.assertEqual(type_parsing, FilePath)


### PR DESCRIPTION
Add support for two additional JSON Schema string formats:
- 'binary' -> bytes (for base64-encoded binary data)
- 'file-path' -> FilePath (for filesystem paths)