### PR TITLE
fix: fixes object naming rules

### DIFF
--- a/jambo/parser/object_type_parser.py
+++ b/jambo/parser/object_type_parser.py
@@ -1,4 +1,4 @@
-from jambo.exceptions import InternalAssertionException
+from jambo.exceptions import InternalAssertionException, InvalidSchemaException
 from jambo.parser._type_parser import GenericTypeParser
 from jambo.types.json_schema_type import JSONSchema
 from jambo.types.type_parser_options import TypeParserOptions
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic.fields import FieldInfo
 from typing_extensions import Unpack
 
+import re
 import warnings
 
 
@@ -59,6 +60,11 @@ class ObjectTypeParser(GenericTypeParser):
         :param required_keys: List of required keys in the schema.
         :return: A Pydantic model class.
         """
+        if not re.match(r"^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*$", name):
+            raise InvalidSchemaException(
+                "Invalid title for the schema. Please use alphanumeric characters, hyphens and underscores only."
+            )
+
         ref_cache = kwargs.get("ref_cache")
         if ref_cache is None:
             raise InternalAssertionException(

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -785,7 +785,7 @@ class TestSchemaConverter(TestCase):
 
     def test_scoped_ref_schema(self):
         schema: JSONSchema = {
-            "title": "Example Schema",
+            "title": "ExampleSchema",
             "type": "object",
             "properties": {
                 "operating_system": {
@@ -1171,3 +1171,20 @@ class TestSchemaConverter(TestCase):
             "Person", namespace=namespace
         )
         self.assertIsNone(cleared_cached_model)
+
+    def test_raises_on_invalid_schema_name(self):
+        with self.assertRaises(ValueError) as ctx:
+            SchemaConverter.build(
+                {
+                    "title": "Test Schema",
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                    },
+                    "required": ["name"],
+                }
+            )
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid JSON Schema: Invalid title for the schema. Please use alphanumeric characters, hyphens and underscores only.",
+        )


### PR DESCRIPTION
this change fixes arbitrary object naming, while names with spaces technically are permitted in pydantic they result in strange and unexpected behaviours