### PR TITLE
Improve ObjectTypeParser exception message for invalid naming

### DIFF
--- a/jambo/parser/object_type_parser.py
+++ b/jambo/parser/object_type_parser.py
@@ -16,6 +16,8 @@ class ObjectTypeParser(GenericTypeParser):
 
     json_schema_type = "type:object"
 
+    _valid_name_pattern = re.compile(r"^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*$")
+
     def from_properties_impl(
         self, name: str, properties: JSONSchema, **kwargs: Unpack[TypeParserOptions]
     ) -> tuple[type[BaseModel], dict]:
@@ -60,9 +62,10 @@ class ObjectTypeParser(GenericTypeParser):
         :param required_keys: List of required keys in the schema.
         :return: A Pydantic model class.
         """
-        if not re.match(r"^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*$", name):
+        if not cls._valid_name_pattern.match(name):
             raise InvalidSchemaException(
-                "Invalid title for the schema. Please use alphanumeric characters, hyphens and underscores only."
+                f"Invalid name '{name}' for the schema. Object titles and property names"
+                " must use alphanumeric characters, hyphens and underscores only."
             )
 
         ref_cache = kwargs.get("ref_cache")

--- a/tests/test_schema_converter.py
+++ b/tests/test_schema_converter.py
@@ -1186,5 +1186,7 @@ class TestSchemaConverter(TestCase):
             )
         self.assertEqual(
             str(ctx.exception),
-            "Invalid JSON Schema: Invalid title for the schema. Please use alphanumeric characters, hyphens and underscores only.",
+            "Invalid JSON Schema: Invalid name 'Test Schema' for the schema. "
+            "Object titles and property names must use alphanumeric characters, "
+            "hyphens and underscores only.",
         )


### PR DESCRIPTION
This pull request improves validation and error messaging for object schema names in the `ObjectTypeParser` class. The main changes include centralizing the name validation regex, updating the error message for clarity, and updating the corresponding test to match the new message.